### PR TITLE
addWrapper()

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ helpers) that it can't support. For example, anything where you'd want to "bail 
 
 So `ad-hok` provides a "magic" version of `flow()` called [`flowMax()`](#flowmax) that you use as your wrapper function when using any of the corresponding "magic" helpers:
 - [`addPropTypes()`](#addproptypes)
+- [`addWrapper()`](#addwrapper)
 - [`renderNothing()`](#rendernothing)
 - [`returns()`](#returns)
 
 ##### `eslint-plugin-ad-hok`
 
 If you use [ESLint](https://github.com/eslint/eslint), you can use [`eslint-plugin-ad-hok`](https://github.com/helixbass/eslint-plugin-ad-hok) to catch cases where:
-- you forgot to use `flowMax()` when using a "magic" helper (`addPropTypes()`, `renderNothing()` or `returns()`)
+- you forgot to use `flowMax()` when using a "magic" helper (`addPropTypes()`, `addWrapper()`, `renderNothing()` or `returns()`)
 - you use `flowMax()` when a simple `flow()` would suffice
 
 ## API
@@ -80,6 +81,7 @@ If you use [ESLint](https://github.com/eslint/eslint), you can use [`eslint-plug
 * [renderNothing()](#rendernothing)
 * [returns()](#returns)
 * [addPropTypes()](#addproptypes)
+* [addWrapper()](#addwrapper)
 * [flowMax()](#flowmax)
 
 ### `addState()`
@@ -402,6 +404,47 @@ const Maybe = flowMax(
 <Maybe isIt={true} />
 ```
 
+### `addWrapper()`
+
+```js
+addWrapper(
+  ({
+    props: Object,
+    render: (additionalProps: ?Object) => any
+  }) => any
+): Function
+```
+
+A "magic" helper that allows taking control of the rendering of the rest of the `flowMax()`. Use cases could be to render additional JSX/markup wrapping or side-by-side with the JSX returned at the end of the `flowMax()`
+
+The supplied callback receives an object with `props` (the incoming props) and a `render` function. `render()` will render the rest of the `flowMax()`. It optionally accepts additional props to pass to the next step in the `flowMax()` (which will also get "forwarded" the incoming `props`. Additional props passed via `render()` take precedence over forwarded `props`)
+
+Since it's magic, you must wrap with [`flowMax()`](#flowmax) instead of `flow()`
+
+Doesn't wrap any hooks, just a convenience helper
+
+For example:
+
+```js
+const WrapInHeader = ({children, header}) =>
+  <div>
+    <h1>{header}</h1>
+    {children}
+  </div>
+
+const Outer = flowMax(
+  addWrapper(({props, render}) =>
+    <WrapInHeader header={props.header}>
+      {render({style: {color: 'red'}})}
+    </WrapInHeader>
+  ),
+  ({message, style}) =>
+    <span style={style}>{message}</span>
+)
+
+<Outer header="Topsy" message="Turvy"/>
+```
+
 ### `flowMax()`
 
 ```js
@@ -411,7 +454,7 @@ flowMax(
 ): Function
 ```
 
-A wrapper that replaces `flow()` when your pipeline uses a "magic" helper (`addPropTypes()`, `renderNothing()` or `returns()`)
+A wrapper that replaces `flow()` when your pipeline uses a "magic" helper (`addPropTypes()`, `addWrapper()`, `renderNothing()` or `returns()`)
 
 For example:
 

--- a/src/__tests__/addContext.coffee
+++ b/src/__tests__/addContext.coffee
@@ -3,7 +3,7 @@ import {render} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 import {flow} from 'lodash/fp'
 
-import addContext from '../addContext'
+import {addContext} from '..'
 
 NumberContext = React.createContext()
 

--- a/src/__tests__/addEffect.coffee
+++ b/src/__tests__/addEffect.coffee
@@ -3,8 +3,7 @@ import {render, waitForElement} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 import {flow} from 'lodash/fp'
 
-import addState from '../addState'
-import addEffect from '../addEffect'
+import {addState, addEffect} from '..'
 
 # eslint-disable-next-line coffee/prop-types
 DisplayComp = ({x}) ->

--- a/src/__tests__/addHandlers.coffee
+++ b/src/__tests__/addHandlers.coffee
@@ -3,7 +3,7 @@ import {render, fireEvent} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 import {flow} from 'lodash/fp'
 
-import addHandlers from '../addHandlers'
+import {addHandlers} from '..'
 
 Comp = flow(
   addHandlers

--- a/src/__tests__/addPropTypes.coffee
+++ b/src/__tests__/addPropTypes.coffee
@@ -4,9 +4,7 @@ import {render} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 import PropTypes from 'prop-types'
 
-import addPropTypes from '../addPropTypes'
-import addProps from '../addProps'
-import flowMax from '../flowMax'
+import {addPropTypes, addProps, flowMax} from '..'
 
 Comp = flowMax addPropTypes(a: PropTypes.number.isRequired), ({a}) ->
   <div>

--- a/src/__tests__/addProps.coffee
+++ b/src/__tests__/addProps.coffee
@@ -1,4 +1,4 @@
-import addProps from '../addProps'
+import {addProps} from '..'
 
 describe 'addProps', ->
   test 'adds object', ->

--- a/src/__tests__/addRef.coffee
+++ b/src/__tests__/addRef.coffee
@@ -3,7 +3,7 @@ import {render, fireEvent} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 import {flow} from 'lodash/fp'
 
-import addRef from '../addRef'
+import {addRef} from '..'
 
 Comp = flow addRef('inputRef'), ({inputRef}) ->
   <div>

--- a/src/__tests__/addState.coffee
+++ b/src/__tests__/addState.coffee
@@ -3,7 +3,7 @@ import {render, fireEvent} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 import {flow} from 'lodash/fp'
 
-import addState from '../addState'
+import {addState} from '..'
 
 Comp = flow addState('x', 'setX', 'abcd'), ({x, setX}) ->
   <div>

--- a/src/__tests__/addStateHandlers.coffee
+++ b/src/__tests__/addStateHandlers.coffee
@@ -3,7 +3,7 @@ import {render, fireEvent} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 import {flow} from 'lodash/fp'
 
-import addStateHandlers from '../addStateHandlers'
+import {addStateHandlers} from '..'
 
 Comp = flow(
   addStateHandlers

--- a/src/__tests__/addWrapper.coffee
+++ b/src/__tests__/addWrapper.coffee
@@ -1,0 +1,29 @@
+import React from 'react'
+import {render} from 'react-testing-library'
+import 'jest-dom/extend-expect'
+
+import {addWrapper, flowMax} from '..'
+
+# eslint-disable-next-line coffee/prop-types
+Wrapper = ({x, children}) ->
+  <div data-testid="wrapper">
+    <span data-testid="passed-x">{x}</span>
+    {children}
+  </div>
+
+Comp = flowMax(
+  addWrapper ({render: _render, props}) ->
+    <Wrapper x={props.x}>{_render z: 3}</Wrapper>
+  ({y, z}) ->
+    <div>
+      <span data-testid="child-y">{y}</span>
+      <span data-testid="child-z">{z}</span>
+    </div>
+)
+
+describe 'addWrapper', ->
+  test 'works', ->
+    {getByTestId} = render <Comp x="2" y="4" />
+    expect(getByTestId 'child-y').toHaveTextContent '4'
+    expect(getByTestId 'child-z').toHaveTextContent '3'
+    expect(getByTestId 'passed-x').toHaveTextContent '2'

--- a/src/__tests__/branch.coffee
+++ b/src/__tests__/branch.coffee
@@ -2,8 +2,7 @@ import React from 'react'
 import {render} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 
-import branch from '../branch'
-import flowMax from '../flowMax'
+import {branch, flowMax} from '..'
 
 Comp = flowMax(
   branch(

--- a/src/__tests__/flowMax.coffee
+++ b/src/__tests__/flowMax.coffee
@@ -2,8 +2,7 @@ import React from 'react'
 import {render, fireEvent} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 
-import addState from '../addState'
-import flowMax from '../flowMax'
+import {addState, addWrapper, addProps, flowMax} from '..'
 
 Comp = flowMax addState('x', 'setX', 'abcd'), ({x, setX}) ->
   <div>
@@ -11,8 +10,31 @@ Comp = flowMax addState('x', 'setX', 'abcd'), ({x, setX}) ->
     <button onClick={-> setX 'efg'}>update</button>
   </div>
 
+addStuff = flowMax(
+  addWrapper ({render: _render, props}) ->
+    <div>
+      <div data-testid="passed-z">{props.z}</div>
+      {_render y: 2}
+    </div>
+  addProps d: 4
+)
+
+Outer = flowMax addStuff, ({y, d, e}) ->
+  <div>
+    <div data-testid="child-y">{y}</div>
+    <div data-testid="child-d">{d}</div>
+    <div data-testid="child-e">{e}</div>
+  </div>
+
 describe 'flowMax', ->
   test 'works in place of flow()', ->
     {getByText, getByTestId} = render <Comp />
     fireEvent.click getByText /update/
     expect(getByTestId 'a').toHaveTextContent 'efg'
+
+  test 'nesting with magic helpers', ->
+    {getByTestId} = render <Outer z={3} e={5} />
+    expect(getByTestId 'passed-z').toHaveTextContent '3'
+    expect(getByTestId 'child-y').toHaveTextContent '2'
+    expect(getByTestId 'child-d').toHaveTextContent '4'
+    expect(getByTestId 'child-e').toHaveTextContent '5'

--- a/src/__tests__/renderNothing.coffee
+++ b/src/__tests__/renderNothing.coffee
@@ -2,9 +2,7 @@ import React from 'react'
 import {render} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 
-import branch from '../branch'
-import flowMax from '../flowMax'
-import renderNothing from '../renderNothing'
+import {branch, flowMax, renderNothing} from '..'
 
 Comp = flowMax branch((({a}) -> a > 2), renderNothing), ({a, testId}) ->
   <div data-testid={testId}>{a}</div>

--- a/src/addPropTypes.coffee
+++ b/src/addPropTypes.coffee
@@ -1,6 +1,6 @@
 import React from 'react'
 
-markerPropertyName = '__isAddPropTypes'
+markerPropertyName = '__ad-hok-addPropTypes'
 
 # eslint-disable-next-line known-imports/no-unused-vars
 export isAddPropTypes = (func) ->

--- a/src/addWrapper.coffee
+++ b/src/addWrapper.coffee
@@ -1,0 +1,17 @@
+import React from 'react'
+
+markerPropertyName = '__ad-hok-addWrapper'
+
+# eslint-disable-next-line known-imports/no-unused-vars
+export isAddWrapper = (func) ->
+  func[markerPropertyName]
+
+export default (callback) ->
+  ret = (Component) -> (props) ->
+    callback {
+      props
+      render: (additionalProps) ->
+        <Component {...props} {...additionalProps} />
+    }
+  ret[markerPropertyName] = yes
+  ret

--- a/src/flowMax.coffee
+++ b/src/flowMax.coffee
@@ -1,31 +1,48 @@
 import {isAddPropTypes} from './addPropTypes'
 import {isRenderNothing} from './renderNothing'
 import {isReturns} from './returns'
+import {isAddWrapper} from './addWrapper'
+
+getArgumentsPropertyName = '__ad-hok-flowMax-getArguments'
+
+isFlowMax = (func) ->
+  func[getArgumentsPropertyName]
 
 flowMax = (...funcs) ->
-  flowLength = funcs?.length ? 0
-  if flowLength
-    for func, funcIndex in funcs when isAddPropTypes(func)
-      precedingFuncs =
-        if funcIndex is 0
-          []
-        else
-          funcs[0...funcIndex]
-      return flowMax ...precedingFuncs, func flowMax ...funcs[(funcIndex + 1)..]
-  (...args) ->
+  getPrecedingFuncs = (index) ->
+    if index is 0
+      []
+    else
+      funcs[0...index]
+  getFollowingFuncs = (index) ->
+    funcs[(index + 1)..]
+  ret = (...args) ->
+    return args[0] unless funcs?.length
+    flowLength = funcs.length
     index = 0
-    props =
-      if flowLength
-        funcs[0] ...args
-      else
-        args[0]
-    return null if isRenderNothing props
-    return returnsVal[1] if (returnsVal = isReturns props)
-    while ++index < flowLength
+    props = null
+    while index < flowLength
       func ###:### = funcs[index]
-      props = func props
+      if (getNestedFlowMaxArguments = isFlowMax func)
+        funcs ### : ### = [
+          ...getPrecedingFuncs(index)
+          ...getNestedFlowMaxArguments()
+          ...getFollowingFuncs(index)
+        ]
+        continue
+      currentArgs =
+        if index is 0
+          args
+        else
+          [props]
+      if isAddPropTypes(func) or isAddWrapper func
+        return func(flowMax ...getFollowingFuncs(index)) ...currentArgs
+      props = func ...currentArgs
       return null if isRenderNothing props
       return returnsVal[1] if (returnsVal = isReturns props)
+      index++
     props
+  ret[getArgumentsPropertyName] = -> funcs
+  ret
 
 export default flowMax

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -10,6 +10,7 @@ import flowMax from './flowMax'
 import renderNothing from './renderNothing'
 import branch from './branch'
 import returns from './returns'
+import addWrapper from './addWrapper'
 
 export {
   addState
@@ -24,4 +25,5 @@ export {
   renderNothing
   branch
   returns
+  addWrapper
 }


### PR DESCRIPTION
Fixes #4 

In this PR:
- add `addWrapper()` helper for rendering additional content
- "hoist"/"inline" nested `flowMax()`'s for expected behavior