### PR TITLE
addWrapperHOC()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-hok",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Recompose-style React hooks",
   "main": "lib/index.js",
   "scripts": {

--- a/src/__tests__/addWrapperHOC.coffee
+++ b/src/__tests__/addWrapperHOC.coffee
@@ -1,0 +1,24 @@
+import React from 'react'
+import {render} from 'react-testing-library'
+import 'jest-dom/extend-expect'
+
+import {addWrapperHOC, flowMax} from '..'
+
+hoc = (Component) -> (props) ->
+  <div>
+    <span data-testid="hoc-passed-x">{props.x}</span>
+    <Component {...props} z={3} />
+  </div>
+
+Comp = flowMax addWrapperHOC(hoc), ({y, z}) ->
+  <div>
+    <span data-testid="child-y">{y}</span>
+    <span data-testid="child-z">{z}</span>
+  </div>
+
+describe 'addWrapperHOC', ->
+  test 'works', ->
+    {getByTestId} = render <Comp x="2" y="4" />
+    expect(getByTestId 'hoc-passed-x').toHaveTextContent '2'
+    expect(getByTestId 'child-y').toHaveTextContent '4'
+    expect(getByTestId 'child-z').toHaveTextContent '3'

--- a/src/addWrapperHOC.coffee
+++ b/src/addWrapperHOC.coffee
@@ -1,0 +1,15 @@
+import React from 'react'
+
+markerPropertyName = '__ad-hok-addWrapperHOC'
+
+# eslint-disable-next-line known-imports/no-unused-vars
+export isAddWrapperHOC = (func) ->
+  func[markerPropertyName]
+
+export default (hoc) ->
+  ret = (Component) ->
+    WrappedComponent = hoc Component
+
+    (props) -> <WrappedComponent {...props} />
+  ret[markerPropertyName] = yes
+  ret

--- a/src/flowMax.coffee
+++ b/src/flowMax.coffee
@@ -2,6 +2,7 @@ import {isAddPropTypes} from './addPropTypes'
 import {isRenderNothing} from './renderNothing'
 import {isReturns} from './returns'
 import {isAddWrapper} from './addWrapper'
+import {isAddWrapperHOC} from './addWrapperHOC'
 
 getArgumentsPropertyName = '__ad-hok-flowMax-getArguments'
 
@@ -25,7 +26,7 @@ flowMax = (...funcs) ->
           ...getNestedFlowMaxArguments()
           ...getFollowingFuncs(funcIndex)
         )
-      if isAddPropTypes(func) or isAddWrapper func
+      if isAddPropTypes(func) or isAddWrapper(func) or isAddWrapperHOC func
         newFlowMax = flowMax(
           ...getPrecedingFuncs(funcIndex)
           func flowMax ...getFollowingFuncs(funcIndex)

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -11,6 +11,7 @@ import renderNothing from './renderNothing'
 import branch from './branch'
 import returns from './returns'
 import addWrapper from './addWrapper'
+import addWrapperHOC from './addWrapperHOC'
 
 export {
   addState
@@ -26,4 +27,5 @@ export {
   branch
   returns
   addWrapper
+  addWrapperHOC
 }


### PR DESCRIPTION
In this PR:
- add `addWrapperHOC()` variant of `addWrapper()` for situations where you want to "statically" bind an HOC to the rest of the `flowMax()` after it

This came from noticing that in using `addWrapper()` to try and encapsulate an HOC, the binding of the HOC to its wrapped component was happening at "runtime" (ie every time the `render()` callback got called) which seemed like perhaps a bad idea (since typically you'd do eg `export default enhance(Component)` ie call `enhance()` once)

And was seeing lots of rerendering/wasn't usably interactive

So this allows simple wrapping of an HOC where the HOC will only get called once