### PR TITLE
branch() renders component

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,5 @@
 - support callback for addHandlers() initial value (like withHandlers())
 - set displayName (eg addPropTypes(<prevDisplayName>)) in addPropTypes()
+- add addDisplayName()? Figure out how that works wrt babel plugin, things that cause "inner components" eg addWrapper()/branch()
+  - should addWrapper() accept displayName option? or should you put addDisplayName() first after addWrapper()?
 - add to README that you can use (eg `flowMax()`/`returns()`) in non-React contexts 
-- warn in README that with `branch()` you could violate hooks invariants (same hooks in same order) I think?

--- a/src/__tests__/branch.coffee
+++ b/src/__tests__/branch.coffee
@@ -1,8 +1,9 @@
 import React from 'react'
-import {render} from 'react-testing-library'
+import {render, fireEvent} from 'react-testing-library'
 import 'jest-dom/extend-expect'
+import {flow} from 'lodash/fp'
 
-import {branch, flowMax} from '..'
+import {branch, flowMax, renderNothing, addStateHandlers, addState} from '..'
 
 Comp = flowMax(
   branch(
@@ -12,6 +13,27 @@ Comp = flowMax(
   )
   ({a, testId}) ->
     <div data-testid={testId}>{a}</div>
+)
+
+Brancher = flowMax(
+  addStateHandlers {abort: no}, toggleAbort: ({abort}) -> -> abort: not abort
+  branch (({abort}) -> abort), renderNothing()
+  addState 'unused', 'setUnused'
+  ({a, testId, toggleAbort}) ->
+    <div>
+      <div data-testid={testId}>{a}</div>
+      <button onClick={toggleAbort}>toggle abort</button>
+    </div>
+)
+
+Brancher2 = flowMax(
+  branch (({abort}) -> abort), renderNothing()
+  addState 'unused', 'setUnused'
+  ({a, testId, toggleAbort}) ->
+    <div>
+      <div data-testid={testId}>{a}</div>
+      <button onClick={toggleAbort}>toggle abort</button>
+    </div>
 )
 
 describe 'branch', ->
@@ -24,3 +46,32 @@ describe 'branch', ->
     testId = 'fail'
     {getByTestId} = render <Comp a={1} testId={testId} />
     expect(getByTestId testId).toHaveTextContent '-888'
+
+  test 'works with renderNothing()', ->
+    testId = 'renderNothing-branch'
+    {
+      getByTestId
+      getByText
+      queryByTestId
+    } = render <Brancher a={1} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+    fireEvent.click getByText /toggle abort/
+    expect(queryByTestId testId).toBeNull()
+
+  test 'works with renderNothing() when initially rendering nothing', ->
+    testId = 'renderNothing-branch-initial-abort'
+    OuterState = flow(
+      addStateHandlers
+        abort: yes
+      ,
+        toggleAbort: ({abort}) -> -> abort: not abort
+      ({abort, toggleAbort}) ->
+        <div>
+          <Brancher2 abort={abort} a={2} testId={testId} />
+          <button onClick={toggleAbort}>toggle abort</button>
+        </div>
+    )
+    {getByTestId, getByText, queryByTestId} = render <OuterState />
+    expect(queryByTestId testId).toBeNull()
+    fireEvent.click getByText /toggle abort/
+    expect(getByTestId testId).toHaveTextContent '2'

--- a/src/__tests__/branchPure.coffee
+++ b/src/__tests__/branchPure.coffee
@@ -1,0 +1,26 @@
+import React from 'react'
+import {render} from 'react-testing-library'
+import 'jest-dom/extend-expect'
+
+import {branchPure, flowMax} from '..'
+
+Comp = flowMax(
+  branchPure(
+    ({a}) -> a > 2
+    (props) -> {...props, a: 999}
+    (props) -> {...props, a: -888}
+  )
+  ({a, testId}) ->
+    <div data-testid={testId}>{a}</div>
+)
+
+describe 'branchPure', ->
+  test 'works when test passes', ->
+    testId = 'pass'
+    {getByTestId} = render <Comp a={3} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '999'
+
+  test 'works when test fails', ->
+    testId = 'fail'
+    {getByTestId} = render <Comp a={1} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '-888'

--- a/src/__tests__/renderNothing.coffee
+++ b/src/__tests__/renderNothing.coffee
@@ -4,7 +4,7 @@ import 'jest-dom/extend-expect'
 
 import {branch, flowMax, renderNothing} from '..'
 
-Comp = flowMax branch((({a}) -> a > 2), renderNothing), ({a, testId}) ->
+Comp = flowMax branch((({a}) -> a > 2), renderNothing()), ({a, testId}) ->
   <div data-testid={testId}>{a}</div>
 
 describe 'renderNothing', ->

--- a/src/__tests__/returns.coffee
+++ b/src/__tests__/returns.coffee
@@ -1,4 +1,4 @@
-import {flowMax, returns, branch} from '..'
+import {flowMax, returns, branchPure} from '..'
 
 describe 'returns', ->
   test 'works as initial step', ->
@@ -11,9 +11,9 @@ describe 'returns', ->
 
     expect(ret).toBe 3
 
-  test 'works with branch()', ->
+  test 'works with branchPure()', ->
     returnThreeIfGreaterThanOne = flowMax(
-      branch ((x) -> x > 1), returns (val) -> val + 1
+      branchPure ((x) -> x > 1), returns (val) -> val + 1
       ->
         4
     )

--- a/src/addComponentBoundary.coffee
+++ b/src/addComponentBoundary.coffee
@@ -1,0 +1,4 @@
+import addWrapper from './addWrapper'
+
+export default ->
+  addWrapper ({render}) -> render()

--- a/src/branch-avoid-circular-dependency.coffee
+++ b/src/branch-avoid-circular-dependency.coffee
@@ -1,0 +1,5 @@
+export markerPropertyName = '__ad-hok-branch'
+
+# eslint-disable-next-line known-imports/no-unused-vars
+export isBranch = (func) ->
+  func[markerPropertyName]

--- a/src/branch.coffee
+++ b/src/branch.coffee
@@ -1,6 +1,15 @@
+import React from 'react'
+import flowMax from './flowMax'
+import {markerPropertyName} from './branch-avoid-circular-dependency'
+
 export default (test, consequent, alternate = (props) -> props) ->
-  (props) ->
-    if test props
-      consequent props
-    else
-      alternate props
+  ret = (Component) ->
+    ConsequentAsComponent = flowMax consequent, Component
+    AlternateAsComponent = flowMax alternate, Component
+    (props) ->
+      if test props
+        <ConsequentAsComponent {...props} />
+      else
+        <AlternateAsComponent {...props} />
+  ret[markerPropertyName] = yes
+  ret

--- a/src/branchPure.coffee
+++ b/src/branchPure.coffee
@@ -1,0 +1,6 @@
+export default (test, consequent, alternate = (props) -> props) ->
+  (props) ->
+    if test props
+      consequent props
+    else
+      alternate props

--- a/src/flowMax.coffee
+++ b/src/flowMax.coffee
@@ -3,6 +3,7 @@ import {isRenderNothing} from './renderNothing'
 import {isReturns} from './returns'
 import {isAddWrapper} from './addWrapper'
 import {isAddWrapperHOC} from './addWrapperHOC'
+import {isBranch} from './branch-avoid-circular-dependency'
 
 getArgumentsPropertyName = '__ad-hok-flowMax-getArguments'
 
@@ -26,7 +27,12 @@ flowMax = (...funcs) ->
           ...getNestedFlowMaxArguments()
           ...getFollowingFuncs(funcIndex)
         )
-      if isAddPropTypes(func) or isAddWrapper(func) or isAddWrapperHOC func
+      if (
+        isAddPropTypes(func) or
+        isAddWrapper(func) or
+        isAddWrapperHOC(func) or
+        isBranch func
+      )
         newFlowMax = flowMax(
           ...getPrecedingFuncs(funcIndex)
           func flowMax ...getFollowingFuncs(funcIndex)

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -9,6 +9,7 @@ import addContext from './addContext'
 import flowMax from './flowMax'
 import renderNothing from './renderNothing'
 import branch from './branch'
+import branchPure from './branchPure'
 import returns from './returns'
 import addWrapper from './addWrapper'
 import addWrapperHOC from './addWrapperHOC'
@@ -25,7 +26,9 @@ export {
   flowMax
   renderNothing
   branch
+  branchPure
   returns
   addWrapper
   addWrapperHOC
+  # addComponentBoundary
 }

--- a/src/renderNothing.coffee
+++ b/src/renderNothing.coffee
@@ -4,5 +4,5 @@ nonce = {}
 export isRenderNothing = (val) ->
   val is nonce
 
-export default ->
+export default -> ->
   nonce


### PR DESCRIPTION
Fixes #8 

In this PR:
- `branch()` always renders both branches as separate components to avoid hook invariant violations
- add `branchPure()` for when you don't want this behavior (eg when using `flowMax()` in a non-React context)
- breaking change: call `renderNothing()` like `renderNothing()`, not `renderNothing`
- added but not exposed: `addComponentBoundary()`