### PR TITLE
addDisplayName()

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,2 @@
 - support callback for addHandlers() initial value (like withHandlers())
-- set displayName (eg addPropTypes(<prevDisplayName>)) in addPropTypes()
-- add addDisplayName()? Figure out how that works wrt babel plugin, things that cause "inner components" eg addWrapper()/branch()
-  - should addWrapper() accept displayName option? or should you put addDisplayName() first after addWrapper()?
+- should addWrapper() accept displayName option? or should you put addDisplayName() first after addWrapper()?

--- a/TODO
+++ b/TODO
@@ -1,2 +1,5 @@
 - support callback for addHandlers() initial value (like withHandlers())
 - should addWrapper() accept displayName option? or should you put addDisplayName() first after addWrapper()?
+- add to README: addWrapperHOC()
+- add to README: addDisplayName()
+- add to README: babel-plugin-transform-react-display-name-pipe

--- a/src/__tests__/addDisplayName.coffee
+++ b/src/__tests__/addDisplayName.coffee
@@ -1,0 +1,30 @@
+import React from 'react'
+import {render} from 'react-testing-library'
+import 'jest-dom/extend-expect'
+
+import {addDisplayName, flowMax, addProps} from '..'
+
+InitialDisplayName = flowMax addDisplayName('Initial'), addProps(a: 3), ({
+  a
+  testId
+}) ->
+  <div data-testid={testId}>{a}</div>
+
+NonInitialDisplayName = flowMax addProps(a: 4), addDisplayName('NonInitial'), ({
+  a
+  testId
+}) ->
+  <div data-testid={testId}>{a}</div>
+
+describe 'addDisplayName', ->
+  test 'works as initial step', ->
+    expect(InitialDisplayName.displayName).toBe 'Initial'
+    testId = 'initial-step'
+    {getByTestId} = render <InitialDisplayName testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '3'
+
+  test 'works as non-initial step', ->
+    expect(NonInitialDisplayName.displayName).toBe 'NonInitial'
+    testId = 'non-initial-step'
+    {getByTestId} = render <NonInitialDisplayName testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '4'

--- a/src/addDisplayName.coffee
+++ b/src/addDisplayName.coffee
@@ -1,0 +1,10 @@
+markerPropertyName = '__ad-hok-addDisplayName'
+
+# eslint-disable-next-line known-imports/no-unused-vars
+export isAddDisplayName = (func) ->
+  func[markerPropertyName]
+
+export default (displayName) ->
+  ret = (props) -> props
+  ret[markerPropertyName] = [displayName]
+  ret

--- a/src/addWrapperHOC.coffee
+++ b/src/addWrapperHOC.coffee
@@ -6,9 +6,10 @@ markerPropertyName = '__ad-hok-addWrapperHOC'
 export isAddWrapperHOC = (func) ->
   func[markerPropertyName]
 
-export default (hoc) ->
+export default (hoc, {displayName = 'addWrapperHOC()'} = {}) ->
   ret = (Component) ->
     WrappedComponent = hoc Component
+    WrappedComponent.displayName = displayName
 
     (props) -> <WrappedComponent {...props} />
   ret[markerPropertyName] = yes

--- a/src/branch.coffee
+++ b/src/branch.coffee
@@ -5,7 +5,18 @@ import {markerPropertyName} from './branch-avoid-circular-dependency'
 export default (test, consequent, alternate = (props) -> props) ->
   ret = (Component) ->
     ConsequentAsComponent = flowMax consequent, Component
+    if (
+      not ConsequentAsComponent.displayName? or
+      ConsequentAsComponent.displayName is 'ret'
+    )
+      ConsequentAsComponent.displayName = "branch(#{Component.displayName ?
+        ''})"
     AlternateAsComponent = flowMax alternate, Component
+    if (
+      not AlternateAsComponent.displayName? or
+      AlternateAsComponent.displayName is 'ret'
+    )
+      AlternateAsComponent.displayName = "branch(#{Component.displayName ? ''})"
     (props) ->
       if test props
         <ConsequentAsComponent {...props} />

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -14,6 +14,7 @@ import returns from './returns'
 import addWrapper from './addWrapper'
 import addWrapperHOC from './addWrapperHOC'
 import addCallback from './addCallback'
+import addDisplayName from './addDisplayName'
 
 export {
   addState
@@ -32,5 +33,6 @@ export {
   addWrapper
   addWrapperHOC
   addCallback
+  addDisplayName
   # addComponentBoundary
 }

--- a/src/returns.coffee
+++ b/src/returns.coffee
@@ -4,7 +4,7 @@ key = '__ad-hok-returns'
 export isReturns = (val) ->
   try
     return no unless key of val
-    return [yes, val[key]]
+    return [val[key]]
   catch
     return no
 


### PR DESCRIPTION
In this PR:
- new `addDisplayName()` helper for explicitly setting `displayName`
- magic helpers set `displayName` to something appropriate (eg `branch()`)
- `addWrapperHOC()` accepts explicit `displayName` option that gets applied to the HOC-wrapped component