### PR TITLE
addEffect prop-name dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ const Counter = flow(
 ```js
 addEffect(
   callback: (props: Object) => Function,
-  dependencies: Array<any>
+  dependencies: Array<string>
 ): Function
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ addEffect(
 
 Accepts a function of props that returns a function (which gets passed to [`useEffect()`](https://reactjs.org/docs/hooks-reference.html#useeffect)). Used for imperative, possibly effectful code
 
-The optional second argument is an array of values that the effect depends on. It corresponds to the [second argument to `useEffect()`](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect)
+The optional second argument is an array of names of props that the effect depends on. It corresponds to the [second argument to `useEffect()`](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect)
 
 For example:
 
@@ -137,7 +137,13 @@ const Example = flow(
   addState('count', 'setCount', 0),
   addEffect(({count}) => () => {
     document.title = `You clicked ${count} times`
+  }, ['count']),
+  addEffect(() => () => {
+    console.log("I get called on every re-render")
   }),
+  addEffect(() => () => {
+    console.log("I only get called once on mount")
+  }, []),
   ({count, setCount}) =>
     <>
       Count: {count}

--- a/src/__tests__/addEffect.coffee
+++ b/src/__tests__/addEffect.coffee
@@ -29,7 +29,20 @@ Comp2 = flow(
         setX x + 1
     []
   )
-  createFactory DisplayComp
+  ({x, testId}) ->
+    <div data-testid={testId}>{x}</div>
+)
+
+Comp3 = flow(
+  addState 'x', 'setX', 0
+  addEffect(
+    ({x, setX}) ->
+      ->
+        setX x + 1
+    ['y']
+  )
+  ({x, testId}) ->
+    <div data-testid={testId}>{x}</div>
 )
 
 describe 'addEffect', ->
@@ -40,8 +53,16 @@ describe 'addEffect', ->
     expect(updatedEl).toHaveTextContent 'ddd'
 
   test 'passes changed-props arg to useEffect()', ->
-    {queryByText, getByText, rerender} = render <Comp2 />
-    getByText '1'
-    rerender <Comp2 />
-    getByText '1'
-    expect(queryByText '2').toBeNull()
+    testId = 'comp2'
+    {rerender, getByTestId} = render <Comp2 testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+    rerender <Comp2 testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+
+  test 'treats changed-props string arg as prop name', ->
+    testId = 'comp3'
+    {getByTestId, rerender} = render <Comp3 y={1} z={2} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+    rerender <Comp3 y={1} z={3} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+    rerender <Comp3 y={2} z={3} testId={testId} />

--- a/src/addEffect.coffee
+++ b/src/addEffect.coffee
@@ -1,7 +1,10 @@
 import {useEffect} from 'react'
 
 addEffect = (callback, changeProps) -> (props) ->
-  useEffect callback(props), changeProps
+  useEffect callback(props),
+    # TODO: throw nice error if changeProps isn't array/iterable or any changeProp isn't a string?
+    if changeProps?
+      props[changeProp] for changeProp in changeProps
 
   props
 


### PR DESCRIPTION
Fixes #13 

`addEffect()`'s dependencies array was implemented incorrectly - it was passing the array through directly to `useEffect()` when in reality it should have been accepting string prop names and converting them to props to pass as dependencies to `useEffect()`