### PR TITLE
Don't recompute handlers

### DIFF
--- a/src/addHandlers.coffee
+++ b/src/addHandlers.coffee
@@ -1,17 +1,17 @@
-import {useMemo} from 'react'
 import {mapValues} from './util/helpers'
+import useMemoized from './util/useMemoized'
 
 addHandlers = (handlers, dependencyNames) ->
   (props) ->
     createHandlerProps = ->
       mapValues((createHandler) ->
+        handler = createHandler props
         (...args) ->
-          handler = createHandler props
           handler ...args
       ) handlers
 
     handlerProps = if dependencyNames
-      useMemo(
+      useMemoized(
         createHandlerProps
         (props[dependencyName] for dependencyName in dependencyNames)
       )

--- a/src/addProps.coffee
+++ b/src/addProps.coffee
@@ -1,12 +1,12 @@
-import {useMemo} from 'react'
 import {isFunction} from './util/helpers'
+import useMemoized from './util/useMemoized'
 
 addProps = (updater, dependencyNames) -> (props) ->
   getAddedProps = ->
     if isFunction updater then updater props else updater
 
   addedProps = if dependencyNames
-    useMemo(
+    useMemoized(
       getAddedProps
       (props[dependencyName] for dependencyName in dependencyNames)
     )

--- a/src/addStateHandlers.coffee
+++ b/src/addStateHandlers.coffee
@@ -1,5 +1,6 @@
-import {useState, useMemo, useRef} from 'react'
+import {useState, useRef} from 'react'
 import {isFunction, mapValues} from './util/helpers'
+import useMemoized from './util/useMemoized'
 
 addStateHandlers = (initial, handlers, dependencyNames) -> (props) ->
   state = {}
@@ -24,7 +25,7 @@ addStateHandlers = (initial, handlers, dependencyNames) -> (props) ->
     ) handlers
 
   handlerProps = if dependencyNames?
-    useMemo createHandlerProps, [
+    useMemoized createHandlerProps, [
       ...(state[key] for key of useInitial)
       ...(props[dependencyName] for dependencyName in dependencyNames)
     ]

--- a/src/addStateHandlers.coffee
+++ b/src/addStateHandlers.coffee
@@ -1,26 +1,31 @@
-import {useState, useMemo} from 'react'
+import {useState, useMemo, useRef} from 'react'
 import {isFunction, mapValues} from './util/helpers'
 
 addStateHandlers = (initial, handlers, dependencyNames) -> (props) ->
   state = {}
   setters = {}
-  initial ###:### = initial props if isFunction initial
-  for key, val of initial
+  computedInitial = useRef()
+  useInitial = do ->
+    return initial unless isFunction initial
+    computedInitial.current ?= initial props
+    computedInitial.current
+  for key, val of useInitial
     [stateVal, setter] = useState val
     state[key] = stateVal
     setters[key] = setter
 
   createHandlerProps = ->
     mapValues((handler) ->
+      curriedHandler = handler state, props
       (...args) ->
-        updatedState = handler(state, props) ...args
+        updatedState = curriedHandler ...args
         for stateKey, updatedValue of updatedState
           setters[stateKey] updatedValue
     ) handlers
 
   handlerProps = if dependencyNames?
     useMemo createHandlerProps, [
-      ...(state[key] for key of initial)
+      ...(state[key] for key of useInitial)
       ...(props[dependencyName] for dependencyName in dependencyNames)
     ]
   else

--- a/src/util/useMemoized.coffee
+++ b/src/util/useMemoized.coffee
@@ -1,0 +1,18 @@
+import usePrevious from './usePrevious'
+import {useRef} from 'react'
+
+shallowEqualArray = (a, b) ->
+  return no unless a?.length? and b?.length?
+  return no unless a.length is b.length
+  for element, index in a
+    return no unless element is b[index]
+  yes
+
+useMemoized = (compute, dependencies) ->
+  memoizedValueRef = useRef()
+  prevDependencies = usePrevious dependencies
+  unless shallowEqualArray prevDependencies, dependencies
+    memoizedValueRef.current = compute()
+  memoizedValueRef.current
+
+export default useMemoized


### PR DESCRIPTION
Fixes #28 
Fixes #29 
Fixes #30 

In this PR:
- fix `addStateHandlers()` bug where the initial-value-computing function was getting overwritten by the first computed value
- fix `addHandlers()`/`addStateHandlers()` issue where curried handlers were getting recomputed on every invocation of the handlers, which for one thing broke memoization of the handlers
- don't rely on `useMemo()` since it's not guaranteed not to unnecessarily recompute values