### PR TITLE
Specify dependencies using paths/callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If you use [ESLint](https://github.com/eslint/eslint), you can use [`eslint-plug
 
 * [addState()](#addstate)
 * [addEffect()](#addeffect)
+* [addLayoutEffect()](#addlayouteffect)
 * [addProps()](#addprops)
 * [addPropsOnChange()](#addpropsonchange)
 * [addHandlers()](#addhandlers)
@@ -165,6 +166,42 @@ const Example = flow(
     console.log("I get called on every re-render")
   }),
   addEffect(() => () => {
+    console.log("I only get called once on mount")
+  }, []),
+  ({count, setCount}) =>
+    <>
+      Count: {count}
+      <button onClick={() => setCount(0)}>Reset</button>
+      <button onClick={() => setCount(prevCount => prevCount + 1)}>+</button>
+    </>
+)
+```
+
+### `addLayoutEffect()`
+
+```js
+addLayoutEffect(
+  callback: (props: Object) => Function,
+  dependencies?: Array<string>
+): Function
+```
+
+Accepts a function of props that returns a function (which gets passed to [`useLayoutEffect()`](https://reactjs.org/docs/hooks-reference.html#uselayouteffect)). Used for imperative, possibly effectful code. The signature is identical to `addEffect`, but it fires synchronously after all DOM mutations
+
+The optional second argument is an array of names of props that the effect depends on. It corresponds to the [second argument to `useLayoutEffect()`](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect)
+
+For example:
+
+```js
+const Example = flow(
+  addState('count', 'setCount', 0),
+  addLayoutEffect(({count}) => () => {
+    document.title = `You clicked ${count} times`
+  }, ['count']),
+  addLayoutEffect(() => () => {
+    console.log("I get called on every re-render")
+  }),
+  addLayoutEffect(() => () => {
     console.log("I only get called once on mount")
   }, []),
   ({count, setCount}) =>

--- a/src/__tests__/addLayoutEffect.coffee
+++ b/src/__tests__/addLayoutEffect.coffee
@@ -1,0 +1,127 @@
+import React, {createFactory} from 'react'
+import {render, waitForElement} from 'react-testing-library'
+import 'jest-dom/extend-expect'
+import {flow} from 'lodash/fp'
+
+import {addState, addLayoutEffect} from '..'
+
+# eslint-disable-next-line coffee/prop-types
+DisplayComp = ({x}) ->
+  <div>
+    <div data-testid="a">{x}</div>
+  </div>
+
+Comp = flow(
+  addState 'x', 'setX', 'aaa'
+  addLayoutEffect ({setX}) ->
+    ->
+      # axios.get.mockResolvedValueOnce data: greeting: 'ddd'
+      # {data: {greeting}} = await axios.get 'SOME_URL'
+      setX 'ddd'
+  createFactory DisplayComp
+)
+
+Comp2 = flow(
+  addState 'x', 'setX', 0
+  addLayoutEffect(
+    ({x, setX}) ->
+      ->
+        setX x + 1
+    []
+  )
+  ({x, testId}) ->
+    <div data-testid={testId}>{x}</div>
+)
+
+Comp3 = flow(
+  addState 'x', 'setX', 0
+  addLayoutEffect(
+    ({x, setX}) ->
+      ->
+        setX x + 1
+    ['y']
+  )
+  ({x, testId}) ->
+    <div data-testid={testId}>{x}</div>
+)
+
+PathDependency = flow(
+  addState 'x', 'setX', 0
+  addLayoutEffect(
+    ({x, setX}) ->
+      ->
+        setX x + 1
+    ['y', 'user.id']
+  )
+  ({x, testId}) ->
+    <div data-testid={testId}>{x}</div>
+)
+
+Comp4 = flow(
+  addState 'x', 'setX', 0
+  addLayoutEffect(
+    ({x, setX}) ->
+      ->
+        setX x + 1
+    (prevProps, props) ->
+      prevProps.y < props.y
+  )
+  ({x, testId}) ->
+    <div data-testid={testId}>{x}</div>
+)
+
+describe 'addLayoutEffect', ->
+  test 'fires', ->
+    {getByText, rerender} = render <Comp />
+    rerender <Comp />
+    updatedEl = await waitForElement -> getByText 'ddd'
+    expect(updatedEl).toHaveTextContent 'ddd'
+
+  test 'passes changed-props arg to useLayoutEffect()', ->
+    testId = 'comp2'
+    {rerender, getByTestId} = render <Comp2 testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+    rerender <Comp2 testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+
+  test 'accepts simple dependencies', ->
+    testId = 'comp3'
+    {getByTestId, rerender} = render <Comp3 y={1} z={2} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+
+    rerender <Comp3 y={1} z={3} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+
+    rerender <Comp3 y={2} z={3} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '2'
+
+  test 'accepts path dependencies', ->
+    testId = 'path-dependency'
+    {
+      getByTestId
+      rerender
+    } = render <PathDependency y={1} z={2} testId={testId} user={id: 3} />
+    expect(getByTestId testId).toHaveTextContent '1'
+
+    rerender <PathDependency y={1} z={3} testId={testId} user={id: 3} />
+    expect(getByTestId testId).toHaveTextContent '1'
+
+    rerender <PathDependency y={2} z={3} testId={testId} user={id: 3} />
+    expect(getByTestId testId).toHaveTextContent '2'
+
+    rerender <PathDependency y={2} z={3} testId={testId} user={id: 4} />
+    expect(getByTestId testId).toHaveTextContent '3'
+
+  test 'accepts callback dependencies argument', ->
+    testId = 'comp4'
+    {getByTestId, rerender} = render <Comp4 y={1} z={2} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+
+    rerender <Comp4 y={1} z={3} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+
+    rerender <Comp4 y={0} z={3} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '1'
+
+    rerender <Comp4 y={2} z={3} testId={testId} />
+    expect(getByTestId testId).toHaveTextContent '2'

--- a/src/__tests__/addProps.coffee
+++ b/src/__tests__/addProps.coffee
@@ -11,7 +11,19 @@ Comp = flow(
     ({x}) ->
       console.log 'recomputing y'
       y: x * 2
-    ['x']
+    ['x', 'user.id']
+  )
+  ({y, testId}) ->
+    <div data-testid={testId}>{y}</div>
+)
+
+Comp2 = flow(
+  addProps(
+    ({x}) ->
+      console.log 'recomputing y'
+      y: x * 2
+    (prevProps, props) ->
+      props.x > prevProps.x
   )
   ({y, testId}) ->
     <div data-testid={testId}>{y}</div>
@@ -30,16 +42,44 @@ describe 'addProps', ->
     .mockImplementation ->
 
     testId = 'basic'
-    {getByTestId, rerender} = render <Comp x={2} z={3} testId={testId} />
+    {
+      getByTestId
+      rerender
+    } = render <Comp x={2} z={3} testId={testId} user={id: 3} />
     expect(console.log).toHaveBeenCalledTimes 1
     console.log.mockClear()
     expect(getByTestId testId).toHaveTextContent '4'
 
-    rerender <Comp x={2} z={5} testId={testId} />
+    rerender <Comp x={2} z={5} testId={testId} user={id: 3} />
     expect(console.log).not.toHaveBeenCalled()
     console.log.mockClear()
 
     rerender <Comp x={4} z={5} testId={testId} />
+    expect(console.log).toHaveBeenCalledTimes 1
+    console.log.mockClear()
+    expect(getByTestId testId).toHaveTextContent '8'
+
+    rerender <Comp x={4} z={5} testId={testId} user={id: 4} />
+    expect(console.log).toHaveBeenCalledTimes 1
+    console.log.mockClear()
+    undefined
+
+  test 'works with dependencies callback', ->
+    jest
+    .spyOn console, 'log'
+    .mockImplementation ->
+
+    testId = 'dependencies-callback'
+    {getByTestId, rerender} = render <Comp2 x={2} z={3} testId={testId} />
+    expect(console.log).toHaveBeenCalledTimes 1
+    console.log.mockClear()
+    expect(getByTestId testId).toHaveTextContent '4'
+
+    rerender <Comp2 x={1} z={5} testId={testId} />
+    expect(console.log).not.toHaveBeenCalled()
+    console.log.mockClear()
+
+    rerender <Comp2 x={4} z={5} testId={testId} />
     expect(console.log).toHaveBeenCalledTimes 1
     console.log.mockClear()
     expect(getByTestId testId).toHaveTextContent '8'

--- a/src/addEffect.coffee
+++ b/src/addEffect.coffee
@@ -1,10 +1,42 @@
 import {useEffect} from 'react'
+import {isArray, get, shallowEqualArray} from './util/helpers'
+import usePrevious from './util/usePrevious'
 
-addEffect = (callback, changeProps) -> (props) ->
-  useEffect callback(props),
+isSimpleDependenciesArray = (dependencies) ->
+  return no unless isArray dependencies
+  for element in dependencies
+    if element.indexOf('.') > -1
+      return no
+  yes
+
+addEffect = (callback, dependencies) -> (props) ->
+  # eslint-disable-next-line coffee/no-negated-condition
+  if not dependencies?
+    useEffect callback props
+  else if isSimpleDependenciesArray dependencies
     # TODO: throw nice error if changeProps isn't array/iterable or any changeProp isn't a string?
-    if changeProps?
-      props[changeProp] for changeProp in changeProps
+    useEffect(
+      callback props
+      (props[dependencyPropName] for dependencyPropName in dependencies)
+    )
+  else
+    prevProps = usePrevious props
+    if isArray dependencies
+      useEffect ->
+        return if (
+          prevProps? and
+          shallowEqualArray(
+            (get(dependencyName) prevProps for dependencyName in dependencies)
+            (get(dependencyName) props for dependencyName in dependencies)
+          )
+        )
+
+        callback(props)()
+    else
+      useEffect ->
+        return if prevProps? and not dependencies prevProps, props
+
+        callback(props)()
 
   props
 

--- a/src/addEffect.coffee
+++ b/src/addEffect.coffee
@@ -1,43 +1,6 @@
 import {useEffect} from 'react'
-import {isArray, get, shallowEqualArray} from './util/helpers'
-import usePrevious from './util/usePrevious'
+import createEffectAdder from './createEffectAdder'
 
-isSimpleDependenciesArray = (dependencies) ->
-  return no unless isArray dependencies
-  for element in dependencies
-    if element.indexOf('.') > -1
-      return no
-  yes
-
-addEffect = (callback, dependencies) -> (props) ->
-  # eslint-disable-next-line coffee/no-negated-condition
-  if not dependencies?
-    useEffect callback props
-  else if isSimpleDependenciesArray dependencies
-    # TODO: throw nice error if changeProps isn't array/iterable or any changeProp isn't a string?
-    useEffect(
-      callback props
-      (props[dependencyPropName] for dependencyPropName in dependencies)
-    )
-  else
-    prevProps = usePrevious props
-    if isArray dependencies
-      useEffect ->
-        return if (
-          prevProps? and
-          shallowEqualArray(
-            (get(dependencyName) prevProps for dependencyName in dependencies)
-            (get(dependencyName) props for dependencyName in dependencies)
-          )
-        )
-
-        callback(props)()
-    else
-      useEffect ->
-        return if prevProps? and not dependencies prevProps, props
-
-        callback(props)()
-
-  props
+addEffect = createEffectAdder useEffect
 
 export default addEffect

--- a/src/addHandlers.coffee
+++ b/src/addHandlers.coffee
@@ -1,7 +1,7 @@
 import {mapValues} from './util/helpers'
-import useMemoized from './util/useMemoized'
+import useComputedFromDependencies from './util/useComputedFromDependencies'
 
-addHandlers = (handlers, dependencyNames) ->
+addHandlers = (handlers, dependencies) ->
   (props) ->
     createHandlerProps = ->
       mapValues((createHandler) ->
@@ -10,13 +10,11 @@ addHandlers = (handlers, dependencyNames) ->
           handler ...args
       ) handlers
 
-    handlerProps = if dependencyNames
-      useMemoized(
-        createHandlerProps
-        (props[dependencyName] for dependencyName in dependencyNames)
-      )
-    else
-      createHandlerProps()
+    handlerProps = useComputedFromDependencies {
+      compute: createHandlerProps
+      dependencies
+      props
+    }
 
     {
       ...props

--- a/src/addLayoutEffect.coffee
+++ b/src/addLayoutEffect.coffee
@@ -1,0 +1,6 @@
+import {useLayoutEffect} from 'react'
+import createEffectAdder from './createEffectAdder'
+
+addLayoutEffect = createEffectAdder useLayoutEffect
+
+export default addLayoutEffect

--- a/src/addProps.coffee
+++ b/src/addProps.coffee
@@ -1,15 +1,27 @@
-import {isFunction} from './util/helpers'
+import {isFunction, get} from './util/helpers'
 import useMemoized from './util/useMemoized'
+import usePrevious from './util/usePrevious'
+import {useRef} from 'react'
 
-addProps = (updater, dependencyNames) -> (props) ->
+addProps = (updater, dependencies) -> (props) ->
   getAddedProps = ->
     if isFunction updater then updater props else updater
 
-  addedProps = if dependencyNames
-    useMemoized(
-      getAddedProps
-      (props[dependencyName] for dependencyName in dependencyNames)
-    )
+  addedProps = if dependencies
+    if isFunction dependencies
+      prevProps = usePrevious props
+      computedValueRef = useRef()
+      changed = not prevProps? or dependencies prevProps, props
+      value = if changed
+        getAddedProps()
+      else
+        computedValueRef.current
+      computedValueRef.current = value
+    else
+      useMemoized(
+        getAddedProps
+        (get(dependencyName) props for dependencyName in dependencies)
+      )
   else
     getAddedProps()
 

--- a/src/addProps.coffee
+++ b/src/addProps.coffee
@@ -1,29 +1,15 @@
-import {isFunction, get} from './util/helpers'
-import useMemoized from './util/useMemoized'
-import usePrevious from './util/usePrevious'
-import {useRef} from 'react'
+import {isFunction} from './util/helpers'
+import useComputedFromDependencies from './util/useComputedFromDependencies'
 
 addProps = (updater, dependencies) -> (props) ->
   getAddedProps = ->
     if isFunction updater then updater props else updater
 
-  addedProps = if dependencies
-    if isFunction dependencies
-      prevProps = usePrevious props
-      computedValueRef = useRef()
-      changed = not prevProps? or dependencies prevProps, props
-      value = if changed
-        getAddedProps()
-      else
-        computedValueRef.current
-      computedValueRef.current = value
-    else
-      useMemoized(
-        getAddedProps
-        (get(dependencyName) props for dependencyName in dependencies)
-      )
-  else
-    getAddedProps()
+  addedProps = useComputedFromDependencies {
+    compute: getAddedProps
+    dependencies
+    props
+  }
 
   {
     ...props

--- a/src/addPropsOnChange.coffee
+++ b/src/addPropsOnChange.coffee
@@ -1,24 +1,6 @@
 import addProps from './addProps'
-import usePrevious from './util/usePrevious'
-import {isArray} from './util/helpers'
 
 addPropsOnChange = (didChange, getProps) ->
-  return addProps getProps, didChange if isArray didChange
-
-  prevAddedProps = null
-
-  (props) ->
-    prevProps = usePrevious props
-    changed = not prevAddedProps or not prevProps? or didChange prevProps, props
-    addedProps = if changed
-      getProps props
-    else
-      prevAddedProps
-    prevAddedProps = addedProps
-
-    {
-      ...props
-      ...addedProps
-    }
+  return addProps getProps, didChange
 
 export default addPropsOnChange

--- a/src/createEffectAdder.coffee
+++ b/src/createEffectAdder.coffee
@@ -1,0 +1,42 @@
+import {isArray, get, shallowEqualArray} from './util/helpers'
+import usePrevious from './util/usePrevious'
+
+isSimpleDependenciesArray = (dependencies) ->
+  return no unless isArray dependencies
+  for element in dependencies
+    if element.indexOf('.') > -1
+      return no
+  yes
+
+createEffectAdder = (effectHook) -> (callback, dependencies) -> (props) ->
+  # eslint-disable-next-line coffee/no-negated-condition
+  if not dependencies?
+    effectHook callback props
+  else if isSimpleDependenciesArray dependencies
+    # TODO: throw nice error if changeProps isn't array/iterable or any changeProp isn't a string?
+    effectHook(
+      callback props
+      (props[dependencyPropName] for dependencyPropName in dependencies)
+    )
+  else
+    prevProps = usePrevious props
+    if isArray dependencies
+      effectHook ->
+        return if (
+          prevProps? and
+          shallowEqualArray(
+            (get(dependencyName) prevProps for dependencyName in dependencies)
+            (get(dependencyName) props for dependencyName in dependencies)
+          )
+        )
+
+        callback(props)()
+    else
+      effectHook ->
+        return if prevProps? and not dependencies prevProps, props
+
+        callback(props)()
+
+  props
+
+export default createEffectAdder

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,7 @@
 import addState from './addState'
 import addStateHandlers from './addStateHandlers'
 import addEffect from './addEffect'
+import addLayoutEffect from './addLayoutEffect'
 import addProps from './addProps'
 import addRef from './addRef'
 import addHandlers from './addHandlers'
@@ -21,6 +22,7 @@ export {
   addState
   addStateHandlers
   addEffect
+  addLayoutEffect
   addProps
   addRef
   addHandlers

--- a/src/util/helpers.coffee
+++ b/src/util/helpers.coffee
@@ -14,3 +14,13 @@ export mapValues = (callback) -> (obj) ->
   for key, val of obj
     ret[key] = callback val
   ret
+
+# eslint-disable-next-line known-imports/no-unused-vars
+export get = (path) ->
+  pathParts = path.split '.'
+  (obj) ->
+    val = obj
+    for pathPart in pathParts
+      return unless val?
+      val = val?[pathPart]
+    val

--- a/src/util/helpers.coffee
+++ b/src/util/helpers.coffee
@@ -24,3 +24,11 @@ export get = (path) ->
       return unless val?
       val = val?[pathPart]
     val
+
+# eslint-disable-next-line known-imports/no-unused-vars
+export shallowEqualArray = (a, b) ->
+  return no unless a?.length? and b?.length?
+  return no unless a.length is b.length
+  for element, index in a
+    return no unless element is b[index]
+  yes

--- a/src/util/useComputedFromDependencies.coffee
+++ b/src/util/useComputedFromDependencies.coffee
@@ -3,8 +3,13 @@ import {isFunction, get} from './helpers'
 import usePrevious from './usePrevious'
 import useMemoized from './useMemoized'
 
-useComputedFromDependencies = ({compute, dependencies, props}) ->
-  if dependencies
+useComputedFromDependencies = ({
+  compute
+  dependencies
+  additionalResolvedDependencies = []
+  props
+}) ->
+  if dependencies?
     if isFunction dependencies
       prevProps = usePrevious props
       computedValueRef = useRef()
@@ -15,10 +20,10 @@ useComputedFromDependencies = ({compute, dependencies, props}) ->
         computedValueRef.current
       computedValueRef.current = value
     else
-      useMemoized(
-        compute
-        (get(dependencyName) props for dependencyName in dependencies)
-      )
+      useMemoized compute, [
+        ...(get(dependencyName) props for dependencyName in dependencies)
+        ...additionalResolvedDependencies
+      ]
   else
     compute()
 

--- a/src/util/useComputedFromDependencies.coffee
+++ b/src/util/useComputedFromDependencies.coffee
@@ -1,0 +1,25 @@
+import {useRef} from 'react'
+import {isFunction, get} from './helpers'
+import usePrevious from './usePrevious'
+import useMemoized from './useMemoized'
+
+useComputedFromDependencies = ({compute, dependencies, props}) ->
+  if dependencies
+    if isFunction dependencies
+      prevProps = usePrevious props
+      computedValueRef = useRef()
+      changed = not prevProps? or dependencies prevProps, props
+      value = if changed
+        compute()
+      else
+        computedValueRef.current
+      computedValueRef.current = value
+    else
+      useMemoized(
+        compute
+        (get(dependencyName) props for dependencyName in dependencies)
+      )
+  else
+    compute()
+
+export default useComputedFromDependencies

--- a/src/util/useMemoized.coffee
+++ b/src/util/useMemoized.coffee
@@ -1,12 +1,6 @@
 import usePrevious from './usePrevious'
+import {shallowEqualArray} from './helpers'
 import {useRef} from 'react'
-
-shallowEqualArray = (a, b) ->
-  return no unless a?.length? and b?.length?
-  return no unless a.length is b.length
-  for element, index in a
-    return no unless element is b[index]
-  yes
 
 useMemoized = (compute, dependencies) ->
   memoizedValueRef = useRef()


### PR DESCRIPTION
Fixes #32 

In this PR:
- `addProps()`/`addHandlers()`/`addStateHandlers()`/`addEffect()` can accept a dependencies argument that's a function of previous and current props or that's an array that contains "paths" (eg `user.id`)

Not in this PR:
- update README to reflect these updates (opened #33)