### PR TITLE
instantiate branch components lazily

### DIFF
--- a/src/branch.coffee
+++ b/src/branch.coffee
@@ -4,23 +4,30 @@ import {markerPropertyName} from './branch-avoid-circular-dependency'
 
 export default (test, consequent, alternate = (props) -> props) ->
   ret = (Component) ->
-    ConsequentAsComponent = flowMax consequent, Component
-    if (
-      not ConsequentAsComponent.displayName? or
-      ConsequentAsComponent.displayName is 'ret'
-    )
-      ConsequentAsComponent.displayName = "branch(#{Component.displayName ?
-        ''})"
-    AlternateAsComponent = flowMax alternate, Component
-    if (
-      not AlternateAsComponent.displayName? or
-      AlternateAsComponent.displayName is 'ret'
-    )
-      AlternateAsComponent.displayName = "branch(#{Component.displayName ? ''})"
+    ConsequentAsComponent = null
+    createConsequent = ->
+      Consequent = flowMax(
+        consequent
+        Component
+      )
+      if not Consequent.displayName? or Consequent.displayName is 'ret'
+        Consequent.displayName = "branch(#{Component.displayName ? ''})"
+      Consequent
+    AlternateAsComponent = null
+    createAlternate = ->
+      Alternate = flowMax(
+        alternate
+        Component
+      )
+      if not Alternate.displayName? or Alternate.displayName is 'ret'
+        Alternate.displayName = "branch(#{Component.displayName ? ''})"
+      Alternate
     (props) ->
       if test props
+        ConsequentAsComponent ?= createConsequent()
         <ConsequentAsComponent {...props} />
       else
+        AlternateAsComponent ?= createAlternate()
         <AlternateAsComponent {...props} />
   ret[markerPropertyName] = yes
   ret


### PR DESCRIPTION
In this PR:
- rather than always instantiating the components for both branches of a `branch()` at "evaluation time" (which seems to cause significantly slow evaluation time in components with a large # of branches), instantiate the branch components lazily (at the time they need to first be rendered)