### PR TITLE
Apply display names recursively

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-hok",
-  "version": "0.0.32-dev.1",
+  "version": "0.0.32-dev.2",
   "description": "Recompose-style React hooks",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-hok",
-  "version": "0.0.31",
+  "version": "0.0.32-dev.1",
   "description": "Recompose-style React hooks",
   "main": "lib/index.js",
   "scripts": {
@@ -41,7 +41,7 @@
     "coffeescript": "^2.5.0",
     "eslint": "^6.0.0",
     "eslint-config-prettier": "^3.1.0",
-    "eslint-plugin-coffee": "^0.1.12",
+    "eslint-plugin-coffee": "github:helixbass/eslint-plugin-coffee#eslint-plugin-coffee-v0.1.13-dev.1-gitpkg",
     "eslint-plugin-known-imports": "^0.0.14",
     "eslint-plugin-prettier": "^3.0.0",
     "jest": "^23.6.0",

--- a/src/__tests__/addDisplayName.coffee
+++ b/src/__tests__/addDisplayName.coffee
@@ -54,6 +54,13 @@ WithBranchAndAddWrapper = flowMax(
   -> <div />
 )
 
+NoDisplayNameBranchAndAddWrapper = flowMax(
+  addWrapper ({render: _render}) -> _render()
+  branch (-> false), renderNothing()
+,
+  -> <div />
+)
+
 ### eslint-disable new-cap ###
 
 describe 'addDisplayName', ->
@@ -85,4 +92,9 @@ describe 'addDisplayName', ->
   test 'carries across branch() + addWrapper()', ->
     expect(WithBranchAndAddWrapper().type().type.displayName).toEqual(
       'branch(addWrapper(WithBranchAndAddWrapper))'
+    )
+
+  test 'branch() + addWrapper() with no explicit display name', ->
+    expect(NoDisplayNameBranchAndAddWrapper().type().type.displayName).toEqual(
+      'branch(addWrapper())'
     )

--- a/src/__tests__/addDisplayName.coffee
+++ b/src/__tests__/addDisplayName.coffee
@@ -2,7 +2,15 @@ import React from 'react'
 import {render} from 'react-testing-library'
 import 'jest-dom/extend-expect'
 
-import {addDisplayName, flowMax, addProps} from '..'
+import {
+  addDisplayName
+  flowMax
+  addProps
+  addPropTypes
+  branch
+  renderNothing
+  addWrapper
+} from '..'
 
 InitialDisplayName = flowMax(
   addDisplayName 'Initial'
@@ -18,6 +26,36 @@ NonInitialDisplayName = flowMax(
     <div data-testid={testId}>{a}</div>
 )
 
+WithAddPropTypes = flowMax(
+  addDisplayName 'WithAddPropTypes'
+  addPropTypes {}
+,
+  -> <div />
+)
+
+WithBranch = flowMax(
+  addDisplayName 'WithBranch'
+  branch (-> false), renderNothing()
+,
+  -> <div />
+)
+
+WithAddWrapper = flowMax(
+  addDisplayName 'WithAddWrapper'
+  addWrapper ({render: _render}) -> _render()
+  -> <div />
+)
+
+WithBranchAndAddWrapper = flowMax(
+  addDisplayName 'WithBranchAndAddWrapper'
+  addWrapper ({render: _render}) -> _render()
+  branch (-> false), renderNothing()
+,
+  -> <div />
+)
+
+### eslint-disable new-cap ###
+
 describe 'addDisplayName', ->
   test 'works as initial step', ->
     expect(InitialDisplayName.displayName).toBe 'Initial'
@@ -30,3 +68,21 @@ describe 'addDisplayName', ->
     testId = 'non-initial-step'
     {getByTestId} = render <NonInitialDisplayName testId={testId} />
     expect(getByTestId testId).toHaveTextContent '4'
+
+  test 'carries across addPropTypes()', ->
+    expect(WithAddPropTypes().type.displayName).toEqual(
+      'addPropTypes(WithAddPropTypes)'
+    )
+
+  test 'carries across branch()', ->
+    expect(WithBranch().type.displayName).toEqual 'branch(WithBranch)'
+
+  test 'carries across addWrapper()', ->
+    expect(WithAddWrapper().type.displayName).toEqual(
+      'addWrapper(WithAddWrapper)'
+    )
+
+  test 'carries across branch() + addWrapper()', ->
+    expect(WithBranchAndAddWrapper().type().type.displayName).toEqual(
+      'branch(addWrapper(WithBranchAndAddWrapper))'
+    )

--- a/src/branch.coffee
+++ b/src/branch.coffee
@@ -11,8 +11,12 @@ export default (test, consequent, alternate = (props) -> props) ->
         consequent
         Component
       )
-      if not Consequent.displayName? or Consequent.displayName is 'ret'
-        Consequent.displayName = "branch(#{Component.displayName ? ''})"
+      Consequent.displayName = "branch(#{
+        if not Consequent.displayName? or Consequent.displayName is 'ret'
+          Component.displayName ? ''
+        else
+          Consequent.displayName
+      })"
       Consequent
     AlternateAsComponent = null
     createAlternate = ->
@@ -20,8 +24,12 @@ export default (test, consequent, alternate = (props) -> props) ->
         alternate
         Component
       )
-      if not Alternate.displayName? or Alternate.displayName is 'ret'
-        Alternate.displayName = "branch(#{Component.displayName ? ''})"
+      Alternate.displayName = "branch(#{
+        if not Alternate.displayName? or Alternate.displayName is 'ret'
+          Component.displayName ? ''
+        else
+          Alternate.displayName
+      })"
       Alternate
     (props) ->
       if test props

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,10 +2058,9 @@ eslint-module-utils@^2.4.1:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-coffee@^0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-coffee/-/eslint-plugin-coffee-0.1.12.tgz#1bb2f41b62fd75b258062cd8dfa230c41eaff2c1"
-  integrity sha512-ThsCQLHhuxpQrqV7mH5+Xlf6Zt3rrzAgkvoduhdzoIwa8xRLxXUahAW1R3FGT/ci04f+8Z9kqlz52/9QtVWxtw==
+"eslint-plugin-coffee@github:helixbass/eslint-plugin-coffee#eslint-plugin-coffee-v0.1.13-dev.1-gitpkg":
+  version "0.1.13-dev.1"
+  resolved "https://codeload.github.com/helixbass/eslint-plugin-coffee/tar.gz/38ddc8c2a769d7a0697d38fae6373c8679681e0f"
   dependencies:
     axe-core "^3.4.1"
     babel-eslint "^7.2.2"


### PR DESCRIPTION
In this PR:
- make display names (eg set via `addDisplayName()`) propagate to "hidden generated" components

TODO: add tests