### PR TITLE
Avoid recomputing state initializers

### DIFF
--- a/src/__tests__/addDisplayName.coffee
+++ b/src/__tests__/addDisplayName.coffee
@@ -42,20 +42,20 @@ WithBranch = flowMax(
 
 WithAddWrapper = flowMax(
   addDisplayName 'WithAddWrapper'
-  addWrapper ({render: _render}) -> _render()
+  addWrapper (_render) -> _render()
   -> <div />
 )
 
 WithBranchAndAddWrapper = flowMax(
   addDisplayName 'WithBranchAndAddWrapper'
-  addWrapper ({render: _render}) -> _render()
+  addWrapper (_render) -> _render()
   branch (-> false), renderNothing()
 ,
   -> <div />
 )
 
 NoDisplayNameBranchAndAddWrapper = flowMax(
-  addWrapper ({render: _render}) -> _render()
+  addWrapper (_render) -> _render()
   branch (-> false), renderNothing()
 ,
   -> <div />

--- a/src/__tests__/addRef.coffee
+++ b/src/__tests__/addRef.coffee
@@ -43,3 +43,16 @@ describe 'addRef', ->
       {getByText} = render <CompWithInitialValueFromProps />
       getByText 'initial'
       undefined
+  test 'initial state only gets computed once', ->
+    getInitial = jest.fn -> 1
+    Component = flow(
+      addRef 'x', getInitial
+      ({x}) ->
+        <div>
+          <div data-testid="c">{x.current}</div>
+        </div>
+    )
+    {getByTestId, rerender} = render <Component />
+    expect(getByTestId 'c').toHaveTextContent '1'
+    rerender <Component />
+    expect(getInitial).toHaveBeenCalledTimes 1

--- a/src/__tests__/addState.coffee
+++ b/src/__tests__/addState.coffee
@@ -35,3 +35,17 @@ describe 'addState', ->
   test 'initial state from props', ->
     {getByTestId} = render <Comp2 initial="aaa" />
     expect(getByTestId 'b').toHaveTextContent 'aaa'
+
+  test 'initial state only gets computed once', ->
+    getInitial = jest.fn -> 1
+    Component = flow(
+      addState 'x', 'setX', getInitial
+      ({x}) ->
+        <div>
+          <div data-testid="c">{x}</div>
+        </div>
+    )
+    {getByTestId, rerender} = render <Component />
+    expect(getByTestId 'c').toHaveTextContent '1'
+    rerender <Component />
+    expect(getInitial).toHaveBeenCalledTimes 1

--- a/src/__tests__/addStateHandlers.coffee
+++ b/src/__tests__/addStateHandlers.coffee
@@ -206,3 +206,22 @@ describe 'addStateHandlers', ->
     expect(console.log).toHaveBeenCalledTimes 1
     console.log.mockClear()
     expect(getByTestId testId).toHaveTextContent '3'
+
+  test 'initial state only gets computed once', ->
+    getInitial = jest.fn -> x: 1
+    Component = flow(
+      addStateHandlers(
+        -> getInitial()
+        incrementX: ({x}) -> ({by: amount = 1} = {}) -> x: x + amount
+      )
+      ({x, incrementX}) ->
+        <div>
+          <div data-testid="c">{x}</div>
+          <button onClick={incrementX}>increment</button>
+          <button onClick={-> incrementX by: 2}>two</button>
+        </div>
+    )
+    {getByTestId, rerender} = render <Component />
+    expect(getByTestId 'c').toHaveTextContent '9'
+    rerender <Component />
+    expect(getInitial).toHaveBeenCalledTimes 1

--- a/src/addRef.coffee
+++ b/src/addRef.coffee
@@ -1,12 +1,20 @@
 import {useRef} from 'react'
 
 import {isFunction} from './util/helpers'
+import useMemoized from './util/useMemoized'
 
 addRef = (name, initialValue) ->
   (props) ->
-    ref = useRef(
-      if isFunction initialValue then initialValue props else initialValue
+    computedInitialValue = useMemoized(
+      ->
+        if isFunction initialValue
+          initialValue props
+        else
+          initialValue
+    ,
+      []
     )
+    ref = useRef computedInitialValue
     {...props, [name]: ref}
 
 export default addRef

--- a/src/addState.coffee
+++ b/src/addState.coffee
@@ -1,12 +1,20 @@
 import {useState} from 'react'
 
 import {isFunction} from './util/helpers'
+import useMemoized from './util/useMemoized'
 
 addState = (name, setterName, initial) ->
   (props) ->
-    [state, setter] = useState(
-      if isFunction initial then initial props else initial
+    computedInitial = useMemoized(
+      ->
+        if isFunction initial
+          initial props
+        else
+          initial
+    ,
+      []
     )
+    [state, setter] = useState computedInitial
     {...props, [name]: state, [setterName]: setter}
 
 export default addState


### PR DESCRIPTION
Fixes #58 

In this PR:
- avoid recomputing state initializers for `addState()`/`addRef()` (`addStateHandlers()` was already avoiding recomputing)
- fix a merge issue where `master` was in a broken state