### PR TITLE
Throw nice error message when flowMax() is passed undefined

### DIFF
--- a/src/__tests__/flowMax.coffee
+++ b/src/__tests__/flowMax.coffee
@@ -50,4 +50,9 @@ describe 'flowMax', ->
   test 'throws nice error when passed a non-function', ->
     expect(->
       flowMax notA: 'function'
-    ).toThrow TypeError
+    ).toThrow 'Expected a function'
+
+  test 'throws nice error when passed undefined', ->
+    expect(->
+      flowMax undefined
+    ).toThrow 'Expected a function'

--- a/src/flowMax.coffee
+++ b/src/flowMax.coffee
@@ -28,6 +28,7 @@ flowMax = (...funcs) ->
     "#{wrapperStr}(#{displayName ? ''})"
   if flowLength
     for func, funcIndex in funcs
+      throw new TypeError 'Expected a function' unless isFunction func
       if getNestedFlowMaxArguments = isFlowMax func
         return flowMax(
           ...getPrecedingFuncs(funcIndex)
@@ -63,7 +64,6 @@ flowMax = (...funcs) ->
         return newFlowMax
       if addedDisplayName = isAddDisplayName func
         displayName = addedDisplayName[0]
-      throw new TypeError 'Expected a function' unless isFunction func
   ret = (...args) ->
     return args[0] unless funcs?.length
     index = 0


### PR DESCRIPTION
Fixes #57 

In this PR:
- extend previous fix from #26 to also throw a nice error if undefined/null is passed as an argument to `flowMax()`