### PR TITLE
Handle current Typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "ts-jest": "^26.1.1",
-    "typescript": "^3.9.6"
+    "typescript": "^4.9.4"
   },
   "dependencies": {}
 }

--- a/src/addContext.tsx
+++ b/src/addContext.tsx
@@ -2,7 +2,11 @@ import {useContext, Context} from 'react'
 
 import {CurriedPropsAdder} from './helperTypes'
 
-type AddContextType = <TContextName extends string, TContextValue, TProps>(
+type AddContextType = <
+  TContextName extends string,
+  TContextValue,
+  TProps extends {}
+>(
   context: Context<TContextValue>,
   contextName: TContextName,
 ) => CurriedPropsAdder<

--- a/src/addDefaultProps.tsx
+++ b/src/addDefaultProps.tsx
@@ -5,7 +5,7 @@ import {ValueOrFunctionOfProps, CurriedPropsAdder} from './helperTypes'
 type AddDefaultPropsType = <
   TProps extends {},
   // TAdditionalProps extends Partial<TProps>
-  TAdditionalProps
+  TAdditionalProps extends {}
 >(
   createProps: ValueOrFunctionOfProps<TAdditionalProps, TProps>,
 ) => CurriedPropsAdder<TProps, TAdditionalProps>

--- a/src/addDisplayName.tsx
+++ b/src/addDisplayName.tsx
@@ -2,7 +2,7 @@ import {CurriedUnchangedProps} from './helperTypes'
 
 const markerPropertyName = '__ad-hok-addDisplayName'
 
-type AddDisplayNameType = <TProps>(
+type AddDisplayNameType = <TProps extends {}>(
   displayName: string,
 ) => CurriedUnchangedProps<TProps>
 
@@ -10,7 +10,7 @@ export const isAddDisplayName = (func: Function): [string] | false =>
   markerPropertyName in func && (func as any)[markerPropertyName]
 
 const addDisplayName: AddDisplayNameType = (displayName) => {
-  const ret = <TProps,>(props: TProps) => props
+  const ret = <TProps extends {}>(props: TProps) => props
   ;(ret as any)[markerPropertyName] = [displayName]
   return ret
 }

--- a/src/addHandlers.tsx
+++ b/src/addHandlers.tsx
@@ -3,11 +3,14 @@ import useComputedFromDependencies from './utils/useComputedFromDependencies'
 
 import {CurriedPropsAdder, DependenciesArgument} from './helperTypes'
 
-export interface HandlerCreators<TProps> {
+export interface HandlerCreators<TProps extends {}> {
   [key: string]: (props: TProps) => (...args: any[]) => any
 }
 
-type AddHandlersType = <TCreators extends HandlerCreators<TProps>, TProps>(
+type AddHandlersType = <
+  TCreators extends HandlerCreators<TProps>,
+  TProps extends {}
+>(
   handlerCreators: TCreators,
   dependencies?: DependenciesArgument<TProps>,
 ) => CurriedPropsAdder<

--- a/src/addMemoBoundary.tsx
+++ b/src/addMemoBoundary.tsx
@@ -6,20 +6,19 @@ import isFunction from './utils/isFunction'
 import some from './utils/some'
 import {CurriedUnchangedProps, DependenciesArgument} from './helperTypes'
 
-const memo = <TProps,>(
+const memo = <TProps extends {}>(
   compare: ((prevProps: TProps, props: TProps) => boolean) | undefined,
 ) => (Component: ComponentType<TProps>) => React.memo(Component, compare)
 
-const compareDependenciesArray = <TProps,>(dependencies: string[]) => (
-  prevProps: TProps,
-  props: TProps,
-) =>
+const compareDependenciesArray = <TProps extends {}>(
+  dependencies: string[],
+) => (prevProps: TProps, props: TProps) =>
   !some(
     (dependency) => get(dependency, prevProps) !== get(dependency, props),
     dependencies,
   )
 
-export const addMemoBoundary = <TProps,>(
+export const addMemoBoundary = <TProps extends {}>(
   dependencies?: DependenciesArgument<TProps>,
 ): ((Component: ComponentType<TProps>) => FC<TProps>) => {
   const compareFunc =
@@ -30,7 +29,7 @@ export const addMemoBoundary = <TProps,>(
   return addWrapperHOC(memo<TProps>(compareFunc))
 }
 
-type AddMemoBoundaryType = <TProps>(
+type AddMemoBoundaryType = <TProps extends {}>(
   dependencies?: DependenciesArgument<TProps>,
 ) => CurriedUnchangedProps<TProps>
 

--- a/src/addPropTypes.tsx
+++ b/src/addPropTypes.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentType, FC} from 'react'
+import React, {ComponentType, FC, WeakValidationMap} from 'react'
 import {ValidationMap} from 'prop-types'
 
 import {CurriedUnchangedProps} from './helperTypes'
@@ -8,11 +8,14 @@ const markerPropertyName = '__ad-hok-addPropTypes'
 export const isAddPropTypes = (func: Function): boolean =>
   markerPropertyName in func
 
-type AddPropTypesType = <TPropTypes, TProps>(
+type AddPropTypesType = <TPropTypes, TProps extends {}>(
   propTypes: ValidationMap<TPropTypes>,
 ) => CurriedUnchangedProps<TProps>
 
-export const addPropTypes = <TPropTypes, TProps>(
+export const addPropTypes = <
+  TPropTypes extends WeakValidationMap<TProps>,
+  TProps extends {}
+>(
   propTypes: TPropTypes,
 ): ((Component: ComponentType<TProps>) => FC<TProps>) => {
   const ret = (Component: ComponentType<TProps>) => {

--- a/src/addReducer.tsx
+++ b/src/addReducer.tsx
@@ -4,7 +4,7 @@ import isFunction from './utils/isFunction'
 import useMemoized from './utils/useMemoized'
 import {ValueOrFunctionOfProps} from './helperTypes'
 
-type AddReducerType = <TState, TAction, TProps>(
+type AddReducerType = <TState extends {}, TAction, TProps extends {}>(
   reducer: Reducer<TState, TAction>,
   initialState: ValueOrFunctionOfProps<TState, TProps>,
 ) => (

--- a/src/addRef.tsx
+++ b/src/addRef.tsx
@@ -4,7 +4,7 @@ import isFunction from './utils/isFunction'
 import useMemoized from './utils/useMemoized'
 import {ValueOrFunctionOfProps, CurriedPropsAdder} from './helperTypes'
 
-type AddRefType = <TRefName extends string, TRefValue, TProps>(
+type AddRefType = <TRefName extends string, TRefValue, TProps extends {}>(
   refName: TRefName,
   initialValue?: ValueOrFunctionOfProps<TRefValue, TProps>,
 ) => CurriedPropsAdder<
@@ -14,7 +14,11 @@ type AddRefType = <TRefName extends string, TRefValue, TProps>(
   }
 >
 
-const addRef: AddRefType = <TRefName extends string, TRefValue, TProps>(
+const addRef: AddRefType = <
+  TRefName extends string,
+  TRefValue,
+  TProps extends {}
+>(
   name: TRefName,
   initialValue:
     | TRefValue

--- a/src/addState.tsx
+++ b/src/addState.tsx
@@ -8,7 +8,7 @@ type AddStateType = <
   TState,
   TStateName extends string,
   TStateUpdaterName extends string,
-  TProps
+  TProps extends {}
 >(
   stateName: TStateName,
   stateUpdaterName: TStateUpdaterName,

--- a/src/addStateHandlers.tsx
+++ b/src/addStateHandlers.tsx
@@ -5,7 +5,7 @@ import mapValues from './utils/mapValues'
 import useMemoized from './utils/useMemoized'
 import {ValueOrFunctionOfProps, CurriedPropsAdder} from './helperTypes'
 
-interface StateUpdaters<TProps, TState> {
+interface StateUpdaters<TProps extends {}, TState extends {}> {
   [key: string]: (
     state: TState,
     props: TProps,
@@ -14,8 +14,8 @@ interface StateUpdaters<TProps, TState> {
 
 type AddStateHandlersType = <
   Updaters extends StateUpdaters<TProps, TState>,
-  TProps,
-  TState
+  TProps extends {},
+  TState extends {}
 >(
   initialState: ValueOrFunctionOfProps<TState, TProps>,
   stateUpdaters: Updaters,
@@ -68,8 +68,8 @@ const addStateHandlers: AddStateHandlersType = (initial, handlers) => (
 
 type AddStateHandlersPublishedType = <
   Updaters extends StateUpdaters<TProps, TState>,
-  TProps,
-  TState
+  TProps extends {},
+  TState extends {}
 >(
   initialState: ValueOrFunctionOfProps<TState, TProps>,
   stateUpdaters: Updaters,

--- a/src/addWrapper.tsx
+++ b/src/addWrapper.tsx
@@ -7,20 +7,20 @@ const markerPropertyName = '__ad-hok-addWrapper'
 export const isAddWrapper = (func: Function): boolean =>
   markerPropertyName in func
 
-export type AddWrapperRenderCallback<TAdditionalProps> = (
+export type AddWrapperRenderCallback<TAdditionalProps extends {}> = (
   additionalProps?: TAdditionalProps,
 ) => ReactElement | null
 
-type AddWrapperCallback<TAdditionalProps, TProps> = (
+type AddWrapperCallback<TAdditionalProps extends {}, TProps extends {}> = (
   render: AddWrapperRenderCallback<TAdditionalProps>,
   props: TProps,
 ) => ReactElement | null
 
-type AddWrapperPublishedType = <TAdditionalProps, TProps>(
+type AddWrapperPublishedType = <TAdditionalProps extends {}, TProps extends {}>(
   callback: AddWrapperCallback<TAdditionalProps, TProps>,
 ) => CurriedPropsAdder<TProps, TAdditionalProps>
 
-export const addWrapper = <TProps, TAdditionalProps>(
+export const addWrapper = <TProps extends {}, TAdditionalProps extends {}>(
   callback: AddWrapperCallback<TAdditionalProps, TProps>,
 ): ((
   Component: ComponentType<TProps & TAdditionalProps>,

--- a/src/addWrapperHOC.tsx
+++ b/src/addWrapperHOC.tsx
@@ -7,11 +7,11 @@ const markerPropertyName = '__ad-hok-addWrapperHOC'
 export const isAddWrapperHOC = (func: Function): boolean =>
   markerPropertyName in func
 
-export type PropAddingHOC<TAddedProps> = (
+export type PropAddingHOC<TAddedProps extends {}> = (
   Component: ComponentType<any>,
 ) => ComponentType<any>
 
-export const addWrapperHOC = <TProps,>(
+export const addWrapperHOC = <TProps extends {}>(
   hoc: (Component: ComponentType<TProps>) => ComponentType<any>,
   {displayName = 'addWrapperHOC()'} = {},
 ): ((Component: ComponentType<TProps>) => FC<TProps>) => {
@@ -25,7 +25,7 @@ export const addWrapperHOC = <TProps,>(
   return ret
 }
 
-type AddWrapperHOCType = <AddedProps, TProps>(
+type AddWrapperHOCType = <AddedProps extends {}, TProps extends {}>(
   hoc: PropAddingHOC<AddedProps>,
 ) => CurriedPropsAdder<TProps, AddedProps>
 

--- a/src/branch.tsx
+++ b/src/branch.tsx
@@ -4,7 +4,7 @@ import flowMax from './flowMax'
 import {markerPropertyName} from './branch-avoid-circular-dependency'
 import {CurriedUnchangedProps, CurriedPropsAdder} from './helperTypes'
 
-export const branch = <TProps, TAdditionalProps>(
+export const branch = <TProps extends {}, TAdditionalProps extends {}>(
   test: (props: TProps) => boolean,
   consequent: (props: TProps) => TProps & TAdditionalProps,
   alternate: (props: TProps) => TProps & TAdditionalProps = (props) =>
@@ -51,12 +51,12 @@ export const branch = <TProps, TAdditionalProps>(
   return ret
 }
 
-type BranchOneBranchType = <TProps>(
+type BranchOneBranchType = <TProps extends {}>(
   test: (props: TProps) => boolean,
   left: (props: TProps) => any,
 ) => CurriedUnchangedProps<TProps>
 
-type BranchTwoBranchType = <TRightProps, TProps>(
+type BranchTwoBranchType = <TRightProps extends {}, TProps extends {}>(
   test: (props: TProps) => boolean,
   left: (props: TProps) => any,
   right: (props: TProps) => TRightProps,

--- a/src/branchPure.tsx
+++ b/src/branchPure.tsx
@@ -1,6 +1,6 @@
 import {BranchType} from './branch'
 
-const branchPure = <TProps,>(
+const branchPure = <TProps extends {}>(
   test: (props: TProps) => boolean,
   consequent: (props: TProps) => any,
   alternate: (props: TProps) => unknown = (props) => props,

--- a/src/helperTypes.ts
+++ b/src/helperTypes.ts
@@ -1,19 +1,19 @@
-export type ValueOrFunctionOfProps<TValue, TProps> =
+export type ValueOrFunctionOfProps<TValue, TProps extends {}> =
   | TValue
   | ((props: TProps) => TValue)
 
-export type CurriedPropsAdder<TProps, AdditionalProps> = (
+export type CurriedPropsAdder<TProps extends {}, AdditionalProps extends {}> = (
   props: TProps,
 ) => TProps & AdditionalProps
 
-export type SimplePropsAdder<AdditionalProps> = <TProps>(
+export type SimplePropsAdder<AdditionalProps extends {}> = <TProps extends {}>(
   props: TProps,
 ) => TProps & AdditionalProps
 
-export type CurriedUnchangedProps<TProps> = (props: TProps) => TProps
+export type CurriedUnchangedProps<TProps extends {}> = (props: TProps) => TProps
 
-export type SimpleUnchangedProps = <TProps>(props: TProps) => TProps
+export type SimpleUnchangedProps = <TProps extends {}>(props: TProps) => TProps
 
-export type DependenciesArgument<TProps> =
+export type DependenciesArgument<TProps extends {}> =
   | string[]
   | ((prevProps: TProps, props: TProps) => boolean)

--- a/src/renderNothing.tsx
+++ b/src/renderNothing.tsx
@@ -4,11 +4,15 @@ const nonce = {}
 
 export const isRenderNothing = (value: unknown): boolean => value === nonce
 
-type RenderNothingType = <TProps>() => (props: TProps) => typeof nonce
+type RenderNothingType = <TProps extends {}>() => (
+  props: TProps,
+) => typeof nonce
 
 export const renderNothing: RenderNothingType = () => (_props) => nonce
 
-type RenderNothingPublishedType = <TProps>() => CurriedUnchangedProps<TProps>
+type RenderNothingPublishedType = <
+  TProps extends {}
+>() => CurriedUnchangedProps<TProps>
 
 const renderNothingPublishedType = renderNothing as RenderNothingPublishedType
 export default renderNothingPublishedType

--- a/src/returns.tsx
+++ b/src/returns.tsx
@@ -11,7 +11,7 @@ export const isReturns = (props: {}): [unknown] | false => {
   }
 }
 
-type ReturnsType = <TProps, TReturn>(
+type ReturnsType = <TProps extends {}, TReturn>(
   callback: (props: TProps) => TReturn,
 ) => (
   props: TProps,
@@ -23,7 +23,7 @@ export const returns: ReturnsType = (callback) => (props) => ({
   [key]: callback(props),
 })
 
-type ReturnsPublishedType = <TProps>(
+type ReturnsPublishedType = <TProps extends {}>(
   callback: (props: TProps) => unknown,
 ) => CurriedUnchangedProps<TProps>
 

--- a/src/utils/createEffectAdder.tsx
+++ b/src/utils/createEffectAdder.tsx
@@ -20,7 +20,7 @@ const isSimpleDependenciesArray = (
 
 type CreateEffectAdderType = (
   effectHook: typeof useEffect | typeof useLayoutEffect,
-) => <TProps>(
+) => <TProps extends {}>(
   callback: (props: TProps) => () => void | (() => void | undefined),
   dependencies?: DependenciesArgument<TProps>,
 ) => CurriedUnchangedProps<TProps>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4216,10 +4216,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.9.6:
-  version "3.9.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
-  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+typescript@^4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This basically adds some `extends {}` constraints to eg `TProps`'s that seems to appease newer versions of Typescript